### PR TITLE
Use YAML prompt files and add Korean docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
-# hr-generation-pipeline
-generation pipeline for router training
+# Reasoning Model Evaluation Pipeline
 
-on develop
+이 프로젝트는 다양한 언어 모델의 **Reasoning(추론) 모드**를 정량적으로 비교하기 위한 실험 파이프라인입니다. 모든 구성은 하나의 `config.yaml` 파일로 제어되며, 워커들은 상태 기반으로 독립적으로 동작합니다.
+
+## 구성 요소
+- `orchestrator.py`: 데이터셋과 모델 조합으로 태스크를 생성하여 DB에 저장합니다.
+- `generation_worker.py`: 모델 응답을 생성하고 DB 상태를 업데이트합니다.
+- `evaluation_worker.py`: 생성된 응답을 판정 프롬프트와 루브릭을 이용해 평가합니다.
+- `export.py`: 완료된 태스크를 CSV 또는 Parquet 파일로 추출합니다.
+- `prompts/`: YAML 형식의 판정 프롬프트(`judge_template.yaml`)와 루브릭(`general_rubric.yaml`)이 위치합니다.
+
+## 빠른 시작
+1. `config.yaml` 내용을 환경에 맞게 수정합니다.
+2. 태스크 등록
+   ```bash
+   python orchestrator.py --config config.yaml --setup-only
+   ```
+3. 응답 생성
+   ```bash
+   python generation_worker.py --config config.yaml
+   ```
+4. 응답 평가
+   ```bash
+   python evaluation_worker.py --config config.yaml
+   ```
+5. 결과 내보내기
+   ```bash
+   python export.py --config config.yaml --format csv
+   ```
+
+자세한 사용 방법은 [`docs/usage_ko.md`](docs/usage_ko.md) 문서를 참고하십시오.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,43 @@
+project:
+  name: "Reasoning Model Evaluation"
+  experiment_name: "reasoning_eval_v2_advanced"
+
+database:
+  type: "sqlite"
+  path: "./tasks.db"
+
+dataset:
+  name: "imdb"
+  prompt_column: "text"
+  split: "test[:5]"
+  sample_size: 2
+
+models:
+  - name: "Dummy-Model"
+    path: "/path/to/model"
+
+generation_worker:
+  replicas: 1
+  vllm_engine_params:
+    tensor_parallel_size: 1
+  sampling_params:
+    temperature: 0.7
+    max_tokens: 2048
+  reasoning_control_param:
+    name: "enable_reasoning"
+    on_value: true
+    off_value: false
+
+evaluation_worker:
+  replicas: 1
+  judge_model:
+    type: "openai"
+    name: "gpt-4-turbo"
+  judge_prompt_template_path: "./prompts/judge_template.yaml"
+  rubric_path: "./prompts/general_rubric.yaml"
+  choice_logic:
+    method: "higher_score"
+
+logging:
+  level: "INFO"
+  dir: "./results/logs"

--- a/docs/usage_ko.md
+++ b/docs/usage_ko.md
@@ -1,0 +1,46 @@
+# Reasoning Model Evaluation Pipeline 사용 가이드
+
+이 문서는 파이프라인을 설치하고 실행하는 기본 절차를 설명합니다.
+
+## 1. 환경 준비
+- Python 3.10 이상을 권장합니다.
+- 필요한 패키지는 `pip install -r requirements.txt` 형식으로 설치할 수 있습니다. (현재 예시에서는 표준 라이브러리만 사용합니다.)
+
+## 2. 설정 파일 편집
+`config.yaml` 파일 하나로 실험을 제어합니다. 주요 항목은 다음과 같습니다.
+
+- `database`: SQLite 또는 PostgreSQL 등의 연결 정보를 지정합니다.
+- `dataset`: Hugging Face 데이터셋 이름과 사용할 열을 설정합니다.
+- `models`: 평가할 모델 목록을 나열합니다.
+- `generation_worker`: 응답 생성과 관련된 설정과 추론 on/off 제어 파라미터를 포함합니다.
+- `evaluation_worker`: 판정에 사용할 프롬프트 템플릿과 루브릭 YAML 경로를 지정합니다.
+
+## 3. 태스크 생성
+```bash
+python orchestrator.py --config config.yaml --setup-only
+```
+데이터셋과 모델 조합으로 구성된 모든 태스크가 DB에 `PENDING_GENERATION` 상태로 등록됩니다.
+
+## 4. 응답 생성
+```bash
+python generation_worker.py --config config.yaml
+```
+생성 워커는 `PENDING_GENERATION` 태스크를 처리하여 응답을 저장하고 상태를 `GENERATION_COMPLETE`로 변경합니다.
+
+## 5. 평가 수행
+```bash
+python evaluation_worker.py --config config.yaml
+```
+평가 워커는 생성된 응답을 읽어 점수와 피드백을 부여하고 상태를 `COMPLETE`로 업데이트합니다.
+
+## 6. 결과 내보내기
+```bash
+python export.py --config config.yaml --format csv
+```
+`status`가 `COMPLETE`인 태스크를 CSV 또는 Parquet 형식으로 추출합니다.
+
+## 7. 모니터링
+추가적으로 `monitor.py`와 같은 도구를 구현하여 태스크 상태 분포를 확인할 수 있습니다.
+
+---
+이 가이드는 기본 동작을 설명한 것으로, 실제 연구 환경에 맞추어 워커 수나 평가 로직 등을 확장하여 사용할 수 있습니다.

--- a/evaluation_worker.py
+++ b/evaluation_worker.py
@@ -1,0 +1,107 @@
+"""Evaluation worker for Reasoning Model Evaluation Pipeline.
+
+This worker consumes tasks that already have model responses generated and
+produces scores and feedback for each response.  The evaluation logic is a
+lightweight heuristic placeholder; in a production environment this would
+call an external judge model such as GPT-4.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Any, Dict, Tuple
+
+import yaml
+
+from task_db import (
+    fetch_and_lock_tasks,
+    get_connection,
+    init_db,
+    update_evaluation_failure,
+    update_evaluation_success,
+)
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def load_prompts(cfg: Dict[str, Any]) -> Tuple[str, str]:
+    """Load judge prompt template and rubric from YAML files."""
+    with open(cfg["judge_prompt_template_path"], "r", encoding="utf-8") as f:
+        judge_data = yaml.safe_load(f) or {}
+    with open(cfg["rubric_path"], "r", encoding="utf-8") as f:
+        rubric_data = yaml.safe_load(f) or {}
+    return judge_data.get("template", ""), rubric_data.get("rubric", "")
+
+
+def simple_judge(response: str, rubric: str) -> Dict[str, Any]:
+    """A naive evaluation heuristic.
+
+    Scores responses based on length as a stand-in for a real LLM judge.
+    The rubric text is appended to the feedback for demonstration purposes.
+    """
+    score = min(len(response) // 10, 10)  # 0-10 scale
+    feedback = f"{rubric.strip()} | length={len(response)}" if rubric else f"length={len(response)}"
+    return {"score": score, "feedback": feedback}
+
+
+def process_batch(conn, batch_size: int, rubric: str) -> int:
+    tasks = fetch_and_lock_tasks(
+        conn, "GENERATION_COMPLETE", "EVALUATING", batch_size
+    )
+    if not tasks:
+        return 0
+
+    for row in tasks:
+        task_id = row["task_id"]
+        try:
+            base_eval = simple_judge(row["base_response"] or "", rubric)
+            reasoning_eval = simple_judge(row["reasoning_response"] or "", rubric)
+            # Determine choice
+            if base_eval["score"] > reasoning_eval["score"]:
+                choice = "base"
+            elif base_eval["score"] < reasoning_eval["score"]:
+                choice = "reasoning"
+            else:
+                choice = "tie"
+            update_evaluation_success(
+                conn,
+                task_id,
+                base_eval["score"],
+                reasoning_eval["score"],
+                base_eval["feedback"],
+                reasoning_eval["feedback"],
+                choice,
+            )
+        except Exception as e:  # pragma: no cover
+            update_evaluation_failure(conn, task_id, str(e))
+    return len(tasks)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluation worker")
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
+    parser.add_argument("--batch-size", type=int, default=8, help="Tasks per batch")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    conn = get_connection(cfg["database"])
+    init_db(conn)
+    judge_template, rubric = load_prompts(cfg["evaluation_worker"])
+
+    processed = 0
+    while True:
+        count = process_batch(conn, args.batch_size, rubric)
+        if count == 0:
+            break
+        processed += count
+        time.sleep(0.1)
+
+    print(f"evaluation_worker: processed {processed} tasks")
+
+
+if __name__ == "__main__":
+    main()

--- a/export.py
+++ b/export.py
@@ -1,0 +1,71 @@
+"""Export completed tasks to CSV or Parquet."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+from typing import Any, Dict
+
+import yaml
+
+try:  # pragma: no cover - pandas is optional for CSV export
+    import pandas as pd
+except Exception:  # pragma: no cover
+    pd = None
+
+from task_db import get_connection
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def export_csv(rows, path: str) -> None:
+    fieldnames = rows[0].keys() if rows else []
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(dict(r))
+
+
+def export_parquet(rows, path: str) -> None:
+    if pd is None:
+        raise RuntimeError("pandas is required for parquet export")
+    df = pd.DataFrame([dict(r) for r in rows])
+    df.to_parquet(path, index=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Export results from task DB")
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
+    parser.add_argument(
+        "--format", choices=["csv", "parquet"], default="csv", help="Export format"
+    )
+    parser.add_argument(
+        "--output", default="results/exported_tasks", help="Output file path without extension"
+    )
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    conn = get_connection(cfg["database"])
+
+    cur = conn.cursor()
+    cur.execute("SELECT * FROM tasks WHERE status='COMPLETE'")
+    rows = cur.fetchall()
+
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    out_path = f"{args.output}.{args.format}"
+
+    if args.format == "csv":
+        export_csv(rows, out_path)
+    else:
+        export_parquet(rows, out_path)
+
+    print(f"Exported {len(rows)} rows to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/generation_worker.py
+++ b/generation_worker.py
@@ -1,0 +1,90 @@
+"""Generation worker for Reasoning Model Evaluation Pipeline.
+
+The worker polls the task database for tasks with status
+``PENDING_GENERATION``.  For each task it generates two responses using a
+placeholder generation function (standing in for vLLM) and stores the
+results back to the database.
+
+This worker is intentionally simple: it processes tasks sequentially and
+terminates once no pending tasks remain.  It can be run in multiple
+instances to simulate replicas.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from typing import Any, Dict
+
+import yaml
+
+from task_db import (
+    fetch_and_lock_tasks,
+    get_connection,
+    init_db,
+    update_generation_failure,
+    update_generation_success,
+)
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def fake_vllm_generate(model_name: str, prompt: str, reasoning: bool) -> str:
+    """Placeholder for vLLM generation.
+
+    The actual system would query a model server.  For testing purposes we
+    simply echo the prompt.
+    """
+    prefix = "REASONING" if reasoning else "BASE"
+    return f"[{prefix}][{model_name}] {prompt}"
+
+
+def process_batch(conn, batch_size: int) -> int:
+    tasks = fetch_and_lock_tasks(conn, "PENDING_GENERATION", "GENERATING", batch_size)
+    if not tasks:
+        return 0
+
+    for row in tasks:
+        task_id = row["task_id"]
+        model_name = row["model_name"]
+        prompt = row["prompt"]
+        try:
+            base = fake_vllm_generate(model_name, prompt, reasoning=False)
+            reasoning_resp = fake_vllm_generate(model_name, prompt, reasoning=True)
+            update_generation_success(conn, task_id, base, reasoning_resp)
+        except Exception as e:  # pragma: no cover - placeholder for real errors
+            update_generation_failure(conn, task_id, str(e))
+    return len(tasks)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generation worker")
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
+    parser.add_argument("--batch-size", type=int, default=4, help="Number of tasks per batch")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    conn = get_connection(cfg["database"])
+    init_db(conn)
+
+    processed = 0
+    while True:
+        count = process_batch(conn, args.batch_size)
+        if count == 0:
+            break
+        processed += count
+        # Sleep briefly to emulate polling behaviour
+        time.sleep(0.1)
+
+    print(f"generation_worker: processed {processed} tasks")
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -1,0 +1,81 @@
+"""Orchestrator module for Reasoning Model Evaluation Pipeline.
+
+This script reads a configuration file, creates the task database and
+populates it with all combinations of prompts and models.  Each inserted
+row represents a unit of work that will later be consumed by the
+`generation_worker` and `evaluation_worker`.
+
+The implementation intentionally focuses on clarity and debuggability.
+It does not attempt to cover every optimisation from the design
+specification but instead provides a solid reference implementation that
+can be extended.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import time
+from typing import Any, Dict
+
+import yaml
+
+try:
+    from datasets import load_dataset
+except Exception:  # pragma: no cover - datasets is optional during tests
+    load_dataset = None
+
+from task_db import get_connection, init_db, insert_task
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Orchestrate experiment setup")
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
+    parser.add_argument(
+        "--setup-only",
+        action="store_true",
+        help="Only set up tasks and exit (default behaviour)",
+    )
+    args = parser.parse_args()
+
+    config = load_config(args.config)
+
+    # Database initialisation
+    conn = get_connection(config["database"])
+    init_db(conn)
+
+    # Load prompts
+    dataset_cfg = config["dataset"]
+    if load_dataset is None:
+        raise RuntimeError(
+            "datasets library is required to load prompts. Install `datasets` package."
+        )
+    ds = load_dataset(dataset_cfg["name"], split=dataset_cfg.get("split", "train"))
+    prompts = ds[dataset_cfg.get("prompt_column", "prompt")]
+    sample_size = dataset_cfg.get("sample_size")
+    if sample_size:
+        prompts = prompts[:sample_size]
+
+    # Insert tasks for every (prompt, model) combination
+    for prompt in prompts:
+        for model in config.get("models", []):
+            key = f"{prompt}\0{model['name']}"
+            task_id = hashlib.sha256(key.encode("utf-8")).hexdigest()
+            insert_task(conn, task_id, prompt, model["name"])
+
+    if args.setup_only:
+        print("Task setup complete: tasks stored in DB")
+        return
+
+    print(
+        "Setup complete. Workers can now be started separately to process the tasks."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/prompts/general_rubric.yaml
+++ b/prompts/general_rubric.yaml
@@ -1,0 +1,2 @@
+rubric: |
+  Score from 0 to 10 based on helpfulness.

--- a/prompts/judge_template.yaml
+++ b/prompts/judge_template.yaml
@@ -1,0 +1,2 @@
+template: |
+  You are a helpful judge.

--- a/task_db.py
+++ b/task_db.py
@@ -1,0 +1,125 @@
+import sqlite3
+import time
+from typing import Dict, List, Tuple
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS tasks (
+    task_id TEXT PRIMARY KEY,
+    status TEXT,
+    prompt TEXT,
+    model_name TEXT,
+    base_response TEXT,
+    reasoning_response TEXT,
+    base_score INTEGER,
+    reasoning_score INTEGER,
+    base_feedback TEXT,
+    reasoning_feedback TEXT,
+    choice TEXT,
+    last_updated REAL,
+    error_log TEXT
+)
+"""
+
+def get_connection(db_config: Dict) -> sqlite3.Connection:
+    """Return a sqlite3 connection based on config."""
+    if db_config.get("type", "sqlite") != "sqlite":
+        raise NotImplementedError("Only sqlite databases are supported in this reference implementation.")
+    path = db_config.get("path", "tasks.db")
+    conn = sqlite3.connect(path, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Initialize the tasks table if it does not exist."""
+    conn.execute(SCHEMA)
+    conn.commit()
+
+def insert_task(conn: sqlite3.Connection, task_id: str, prompt: str, model_name: str) -> None:
+    """Insert a new task if it does not already exist."""
+    now = time.time()
+    conn.execute(
+        """
+        INSERT OR IGNORE INTO tasks (task_id, status, prompt, model_name, last_updated)
+        VALUES (?, 'PENDING_GENERATION', ?, ?, ?)
+        """,
+        (task_id, prompt, model_name, now),
+    )
+    conn.commit()
+
+def fetch_and_lock_tasks(conn: sqlite3.Connection, from_status: str, to_status: str, limit: int) -> List[sqlite3.Row]:
+    """Fetch tasks with a given status and immediately lock them by updating their status.
+
+    This prevents multiple workers from processing the same task concurrently.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT * FROM tasks WHERE status=? LIMIT ?", (from_status, limit)
+    )
+    rows = cur.fetchall()
+    if not rows:
+        return []
+    ids = [r["task_id"] for r in rows]
+    placeholders = ",".join(["?"] * len(ids))
+    cur.execute(
+        f"UPDATE tasks SET status=?, last_updated=? WHERE task_id IN ({placeholders})",
+        [to_status, time.time(), *ids],
+    )
+    conn.commit()
+    return rows
+
+def update_generation_success(conn: sqlite3.Connection, task_id: str, base_resp: str, reasoning_resp: str) -> None:
+    conn.execute(
+        """
+        UPDATE tasks SET status='GENERATION_COMPLETE', base_response=?, reasoning_response=?, last_updated=?
+        WHERE task_id=?
+        """,
+        (base_resp, reasoning_resp, time.time(), task_id),
+    )
+    conn.commit()
+
+def update_generation_failure(conn: sqlite3.Connection, task_id: str, error: str) -> None:
+    conn.execute(
+        """
+        UPDATE tasks SET status='FAILED_GENERATION', error_log=?, last_updated=?
+        WHERE task_id=?
+        """,
+        (error, time.time(), task_id),
+    )
+    conn.commit()
+
+def update_evaluation_success(
+    conn: sqlite3.Connection,
+    task_id: str,
+    base_score: int,
+    reasoning_score: int,
+    base_feedback: str,
+    reasoning_feedback: str,
+    choice: str,
+) -> None:
+    conn.execute(
+        """
+        UPDATE tasks SET status='COMPLETE', base_score=?, reasoning_score=?,
+            base_feedback=?, reasoning_feedback=?, choice=?, last_updated=?
+        WHERE task_id=?
+        """,
+        (
+            base_score,
+            reasoning_score,
+            base_feedback,
+            reasoning_feedback,
+            choice,
+            time.time(),
+            task_id,
+        ),
+    )
+    conn.commit()
+
+def update_evaluation_failure(conn: sqlite3.Connection, task_id: str, error: str) -> None:
+    conn.execute(
+        """
+        UPDATE tasks SET status='FAILED_EVALUATION', error_log=?, last_updated=?
+        WHERE task_id=?
+        """,
+        (error, time.time(), task_id),
+    )
+    conn.commit()


### PR DESCRIPTION
## Summary
- replace text prompt templates with YAML versions and load them in evaluation worker
- update config to reference new YAML prompts
- add Korean README and usage guide for easier onboarding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1c5d8de908320885716770f1be58e