### PR TITLE
feat(generation): selectable backends (transformers|vLLM) with robust reasoning on/off control

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,8 +13,8 @@ dataset:
   sample_size: 2
 
 models:
-  - name: "Dummy-Model"
-    path: "/path/to/model"
+  - name: "tiny-gpt2"
+    path: "sshleifer/tiny-gpt2"
 
 generation_worker:
   replicas: 1

--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,13 @@ database:
   path: "./tasks.db"
 
 dataset:
-  name: "imdb"
-  prompt_column: "text"
-  split: "test[:5]"
+  # You can provide inline prompts for quick tests (takes precedence over name/file)
+  prompts:
+    - "Compare reasoning vs base: What is 2+2?"
+    - "Write a short plan to cook pasta."
+  # name: "imdb"
+  # prompt_column: "text"
+  # split: "test[:5]"
   sample_size: 2
 
 models:
@@ -18,11 +22,17 @@ models:
 
 generation_worker:
   replicas: 1
+  backend: "transformers"  # "transformers" or "vllm"
   vllm_engine_params:
     tensor_parallel_size: 1
+    # dtype: "auto"   # optional
   sampling_params:
-    temperature: 0.7
-    max_tokens: 2048
+    temperature: 0.2
+    max_tokens: 64
+  reasoning_prompting:
+    strategy: "append"     # "append" or "prepend"
+    on_text: "Let's think step by step."
+    off_text: ""
   reasoning_control_param:
     name: "enable_reasoning"
     on_value: true

--- a/generation_worker.py
+++ b/generation_worker.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import argparse
 import time
 from typing import Any, Dict
+from functools import lru_cache
 
 import yaml
 
@@ -37,16 +38,36 @@ def load_config(path: str) -> Dict[str, Any]:
 
 
 def fake_vllm_generate(model_name: str, prompt: str, reasoning: bool) -> str:
-    """Placeholder for vLLM generation.
-
-    The actual system would query a model server.  For testing purposes we
-    simply echo the prompt.
-    """
     prefix = "REASONING" if reasoning else "BASE"
     return f"[{prefix}][{model_name}] {prompt}"
 
 
-def process_batch(conn, batch_size: int) -> int:
+@lru_cache(maxsize=4)
+def get_generator(model_id: str):
+    try:
+        from transformers import pipeline  # type: ignore
+    except Exception:
+        return None
+    try:
+        gen = pipeline("text-generation", model=model_id, device=-1)
+        return gen
+    except Exception:
+        return None
+
+
+def generate_text(model_id: str, prompt: str, reasoning: bool, max_new_tokens: int) -> str:
+    gen = get_generator(model_id)
+    if gen is None:
+        # Fallback to echo generation
+        return fake_vllm_generate(model_id, prompt, reasoning)
+    # Add a tiny reasoning cue to differentiate paths
+    eff_prompt = prompt + ("\nLet's think step by step." if reasoning else "")
+    out = gen(eff_prompt, max_new_tokens=max_new_tokens, do_sample=False)
+    text = out[0].get("generated_text", "") if isinstance(out, list) and out else str(out)
+    return text
+
+
+def process_batch(conn, batch_size: int, model_map: Dict[str, str], max_new_tokens: int) -> int:
     tasks = fetch_and_lock_tasks(conn, "PENDING_GENERATION", "GENERATING", batch_size)
     if not tasks:
         return 0
@@ -56,8 +77,11 @@ def process_batch(conn, batch_size: int) -> int:
         model_name = row["model_name"]
         prompt = row["prompt"]
         try:
-            base = fake_vllm_generate(model_name, prompt, reasoning=False)
-            reasoning_resp = fake_vllm_generate(model_name, prompt, reasoning=True)
+            model_id = model_map.get(model_name, model_name)
+            base = generate_text(model_id, prompt, reasoning=False, max_new_tokens=max_new_tokens)
+            reasoning_resp = generate_text(
+                model_id, prompt, reasoning=True, max_new_tokens=max_new_tokens
+            )
             update_generation_success(conn, task_id, base, reasoning_resp)
         except Exception as e:  # pragma: no cover - placeholder for real errors
             update_generation_failure(conn, task_id, str(e))
@@ -74,13 +98,21 @@ def main() -> None:
     conn = get_connection(cfg["database"])
     init_db(conn)
 
+    # Build model name -> HF model id mapping
+    models_cfg = cfg.get("models", [])
+    model_map = {m.get("name", ""): m.get("path", m.get("name", "")) for m in models_cfg if m.get("name")}
+
+    sampling = cfg.get("generation_worker", {}).get("sampling_params", {})
+    max_new_tokens = int(sampling.get("max_tokens", 32))
+    # Keep it small for CPU tests
+    max_new_tokens = max(1, min(max_new_tokens, 64))
+
     processed = 0
     while True:
-        count = process_batch(conn, args.batch_size)
+        count = process_batch(conn, args.batch_size, model_map, max_new_tokens)
         if count == 0:
             break
         processed += count
-        # Sleep briefly to emulate polling behaviour
         time.sleep(0.1)
 
     print(f"generation_worker: processed {processed} tasks")

--- a/generation_worker.py
+++ b/generation_worker.py
@@ -55,22 +55,104 @@ def get_generator(model_id: str):
         return None
 
 
-def generate_text(model_id: str, prompt: str, reasoning: bool, max_new_tokens: int) -> str:
+@lru_cache(maxsize=2)
+def get_vllm(model_id: str, **engine_params):
+    try:
+        from vllm import LLM  # type: ignore
+    except Exception:
+        return None
+    # Filter known-safe params to avoid runtime errors
+    allowed = {
+        "tensor_parallel_size",
+        "dtype",
+        "gpu_memory_utilization",
+        "trust_remote_code",
+        "download_dir",
+        "enforce_eager",
+        "max_num_batched_tokens",
+    }
+    kwargs = {k: v for k, v in engine_params.items() if k in allowed}
+    try:
+        return LLM(model=model_id, **kwargs)
+    except Exception:
+        return None
+
+
+def build_prompt(base_prompt: str, reasoning: bool, prompting: Dict[str, Any], control: Dict[str, Any]) -> str:
+    strategy = (prompting or {}).get("strategy", "append")
+    on_text = (prompting or {}).get("on_text", "Let's think step by step.")
+    off_text = (prompting or {}).get("off_text", "")
+    add = on_text if reasoning else off_text
+
+    control_line = ""
+    if isinstance(control, dict) and control.get("name"):
+        name = str(control["name"]).strip()
+        value = control.get("on_value") if reasoning else control.get("off_value")
+        if name and value is not None:
+            control_line = f"<{name}>{value}</{name}>"
+
+    def join_lines(parts):
+        return "\n".join([p for p in parts if p])
+
+    if strategy == "prepend":
+        return join_lines([control_line, add, base_prompt])
+    # default: append
+    return join_lines([base_prompt, add, control_line])
+
+
+def generate_with_transformers(model_id: str, prompt: str, reasoning: bool, max_new_tokens: int, temperature: float, prompting: Dict[str, Any], control: Dict[str, Any]) -> str:
     gen = get_generator(model_id)
     if gen is None:
-        # Fallback to echo generation
         return fake_vllm_generate(model_id, prompt, reasoning)
-    # Add a tiny reasoning cue to differentiate paths
-    eff_prompt = prompt + ("\nLet's think step by step." if reasoning else "")
-    out = gen(eff_prompt, max_new_tokens=max_new_tokens, do_sample=False)
+    eff_prompt = build_prompt(prompt, reasoning, prompting, control)
+    out = gen(eff_prompt, max_new_tokens=max_new_tokens, do_sample=bool(temperature > 0), temperature=temperature)
     text = out[0].get("generated_text", "") if isinstance(out, list) and out else str(out)
     return text
 
 
-def process_batch(conn, batch_size: int, model_map: Dict[str, str], max_new_tokens: int) -> int:
+def generate_with_vllm(model_id: str, prompt: str, reasoning: bool, max_new_tokens: int, temperature: float, prompting: Dict[str, Any], control: Dict[str, Any], engine_params: Dict[str, Any]) -> str:
+    try:
+        from vllm import SamplingParams  # type: ignore
+    except Exception:
+        return fake_vllm_generate(model_id, prompt, reasoning)
+    llm = get_vllm(model_id, **(engine_params or {}))
+    if llm is None:
+        return fake_vllm_generate(model_id, prompt, reasoning)
+    eff_prompt = build_prompt(prompt, reasoning, prompting, control)
+    sp = SamplingParams(temperature=temperature, max_tokens=max_new_tokens)
+    try:
+        outputs = llm.generate([eff_prompt], sp)
+        if outputs and outputs[0].outputs:
+            return outputs[0].outputs[0].text
+    except Exception:
+        pass
+    return fake_vllm_generate(model_id, prompt, reasoning)
+
+
+def generate_text(backend: str, model_id: str, prompt: str, reasoning: bool, max_new_tokens: int, temperature: float, prompting: Dict[str, Any], control: Dict[str, Any], engine_params: Dict[str, Any]) -> str:
+    backend = (backend or "transformers").lower()
+    if backend == "vllm":
+        return generate_with_vllm(model_id, prompt, reasoning, max_new_tokens, temperature, prompting, control, engine_params)
+    return generate_with_transformers(model_id, prompt, reasoning, max_new_tokens, temperature, prompting, control)
+
+
+def process_batch(
+    conn,
+    batch_size: int,
+    backend: str,
+    model_map: Dict[str, str],
+    sampling: Dict[str, Any],
+    prompting: Dict[str, Any],
+    control: Dict[str, Any],
+    engine_params: Dict[str, Any],
+) -> int:
     tasks = fetch_and_lock_tasks(conn, "PENDING_GENERATION", "GENERATING", batch_size)
     if not tasks:
         return 0
+
+    max_new_tokens = int(sampling.get("max_tokens", 32))
+    max_new_tokens = max(1, min(max_new_tokens, 512))
+    temperature = float(sampling.get("temperature", 0.0))
 
     for row in tasks:
         task_id = row["task_id"]
@@ -78,9 +160,27 @@ def process_batch(conn, batch_size: int, model_map: Dict[str, str], max_new_toke
         prompt = row["prompt"]
         try:
             model_id = model_map.get(model_name, model_name)
-            base = generate_text(model_id, prompt, reasoning=False, max_new_tokens=max_new_tokens)
+            base = generate_text(
+                backend,
+                model_id,
+                prompt,
+                reasoning=False,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                prompting=prompting,
+                control=control,
+                engine_params=engine_params,
+            )
             reasoning_resp = generate_text(
-                model_id, prompt, reasoning=True, max_new_tokens=max_new_tokens
+                backend,
+                model_id,
+                prompt,
+                reasoning=True,
+                max_new_tokens=max_new_tokens,
+                temperature=temperature,
+                prompting=prompting,
+                control=control,
+                engine_params=engine_params,
             )
             update_generation_success(conn, task_id, base, reasoning_resp)
         except Exception as e:  # pragma: no cover - placeholder for real errors
@@ -98,18 +198,29 @@ def main() -> None:
     conn = get_connection(cfg["database"])
     init_db(conn)
 
-    # Build model name -> HF model id mapping
+    # Build model name -> model id mapping
     models_cfg = cfg.get("models", [])
     model_map = {m.get("name", ""): m.get("path", m.get("name", "")) for m in models_cfg if m.get("name")}
 
-    sampling = cfg.get("generation_worker", {}).get("sampling_params", {})
-    max_new_tokens = int(sampling.get("max_tokens", 32))
-    # Keep it small for CPU tests
-    max_new_tokens = max(1, min(max_new_tokens, 64))
+    gw_cfg = cfg.get("generation_worker", {})
+    backend = gw_cfg.get("backend", "transformers")
+    sampling = gw_cfg.get("sampling_params", {})
+    prompting = gw_cfg.get("reasoning_prompting", {})
+    control = gw_cfg.get("reasoning_control_param", {})
+    engine_params = gw_cfg.get("vllm_engine_params", {})
 
     processed = 0
     while True:
-        count = process_batch(conn, args.batch_size, model_map, max_new_tokens)
+        count = process_batch(
+            conn,
+            args.batch_size,
+            backend,
+            model_map,
+            sampling,
+            prompting,
+            control,
+            engine_params,
+        )
         if count == 0:
             break
         processed += count

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -33,6 +33,30 @@ def load_config(path: str) -> Dict[str, Any]:
         return yaml.safe_load(f)
 
 
+def _load_prompts_from_config(config: Dict[str, Any]) -> list[str]:
+    dataset_cfg = config.get("dataset", {})
+    # 1) Inline prompts list
+    if isinstance(dataset_cfg.get("prompts"), list) and dataset_cfg["prompts"]:
+        prompts = [str(p) for p in dataset_cfg["prompts"]]
+    # 2) Local text file (one prompt per line)
+    elif isinstance(dataset_cfg.get("file"), str):
+        path = dataset_cfg["file"]
+        with open(path, "r", encoding="utf-8") as f:
+            prompts = [line.strip() for line in f if line.strip()]
+    # 3) Hugging Face datasets if available
+    elif load_dataset is not None and dataset_cfg.get("name"):
+        ds = load_dataset(dataset_cfg["name"], split=dataset_cfg.get("split", "train"))
+        prompts = ds[dataset_cfg.get("prompt_column", "prompt")]
+    else:
+        # Fallback minimal prompts for offline usage
+        prompts = ["Say hello.", "Summarize: AI helps humans."]
+
+    sample_size = dataset_cfg.get("sample_size")
+    if sample_size:
+        prompts = prompts[: int(sample_size)]
+    return prompts
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Orchestrate experiment setup")
     parser.add_argument("--config", required=True, help="Path to YAML config file")
@@ -49,17 +73,8 @@ def main() -> None:
     conn = get_connection(config["database"])
     init_db(conn)
 
-    # Load prompts
-    dataset_cfg = config["dataset"]
-    if load_dataset is None:
-        raise RuntimeError(
-            "datasets library is required to load prompts. Install `datasets` package."
-        )
-    ds = load_dataset(dataset_cfg["name"], split=dataset_cfg.get("split", "train"))
-    prompts = ds[dataset_cfg.get("prompt_column", "prompt")]
-    sample_size = dataset_cfg.get("sample_size")
-    if sample_size:
-        prompts = prompts[:sample_size]
+    # Load prompts (supports inline/file/HF datasets)
+    prompts = _load_prompts_from_config(config)
 
     # Insert tasks for every (prompt, model) combination
     for prompt in prompts:


### PR DESCRIPTION
Summary
Adds an optional vLLM backend alongside Hugging Face transformers for text generation, and introduces robust reasoning on/off controls that affect prompts deterministically. This enables running the pipeline in lightweight CPU-only mode (transformers + tiny model) while also supporting vLLM where available.

Key Changes
- generation_worker
  - Backend selection via config: "transformers" (default) or "vllm".
  - HF transformers path uses pipeline("text-generation", device=-1) and falls back to echo if unavailable.
  - vLLM path uses LLM + SamplingParams with a safe subset of engine params; falls back to echo if unavailable.
  - Reasoning controls:
    - reasoning_prompting: strategy (append|prepend), on_text, off_text
    - reasoning_control_param: name/on_value/off_value injected as a tag in the prompt, e.g., <enable_reasoning>True</enable_reasoning>
  - Base vs reasoning prompts are now clearly differentiated by both prompting text and control tag.
- config.yaml
  - Adds generation_worker.backend, reasoning_prompting, vllm_engine_params examples, and tuned sampling defaults for CPU tests.
  - Provides inline dataset.prompts for quick offline/local runs.

Why
- Allow users to choose between small local CPU models (transformers) and vLLM when available.
- Make reasoning on/off experiments reproducible and explicitly encoded in the prompt.
- Keep an offline-first/testable setup.

Compatibility
- Backwards compatible with existing model mapping (models[].name -> models[].path).
- If vLLM is not installed or fails to initialize, generation gracefully falls back to a simple echo-like output (for testing).

Config Snippet
- generation_worker:
  - backend: "transformers" | "vllm"
  - reasoning_prompting:
    - strategy: "append" | "prepend"
    - on_text/off_text
  - reasoning_control_param:
    - name/on_value/off_value

Testing Done (local)
1) Setup tasks
   python orchestrator.py --config config.yaml --setup-only
2) Generate (transformers, tiny-gpt2 CPU)
   python generation_worker.py --config config.yaml
3) Evaluate (simple heuristic)
   python evaluation_worker.py --config config.yaml
4) Export
   python export.py --config config.yaml --format csv --output results/exported_tasks_backend

Observed
- generation_worker processed tasks using sshleifer/tiny-gpt2 on CPU.
- Reasoning prompts included both the on_text and control tag when enabled.
- CSV export contained both base and reasoning outputs.

Notes / Follow-ups
- vLLM usage may require GPU/appropriate environment; current code safely falls back if not present.
- Optional future PR: add requirements.txt and .gitignore (tasks.db, results/, __pycache__/), and expand README with offline/local usage and backend options.


@h-albert-lee can click here to [continue refining the PR](https://app.all-hands.dev/conversations/432842cb742048148fce2f777b64beef)