### PR TITLE
Streamline setup and ensure atomic task locking

### DIFF
--- a/evaluation_worker.py
+++ b/evaluation_worker.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import argparse
 import time
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import yaml
 
@@ -28,13 +28,11 @@ def load_config(path: str) -> Dict[str, Any]:
         return yaml.safe_load(f)
 
 
-def load_prompts(cfg: Dict[str, Any]) -> Tuple[str, str]:
-    """Load judge prompt template and rubric from YAML files."""
-    with open(cfg["judge_prompt_template_path"], "r", encoding="utf-8") as f:
-        judge_data = yaml.safe_load(f) or {}
+def load_rubric(cfg: Dict[str, Any]) -> str:
+    """Load evaluation rubric from a YAML file."""
     with open(cfg["rubric_path"], "r", encoding="utf-8") as f:
         rubric_data = yaml.safe_load(f) or {}
-    return judge_data.get("template", ""), rubric_data.get("rubric", "")
+    return rubric_data.get("rubric", "")
 
 
 def simple_judge(response: str, rubric: str) -> Dict[str, Any]:
@@ -90,7 +88,7 @@ def main() -> None:
     cfg = load_config(args.config)
     conn = get_connection(cfg["database"])
     init_db(conn)
-    judge_template, rubric = load_prompts(cfg["evaluation_worker"])
+    rubric = load_rubric(cfg["evaluation_worker"])
 
     processed = 0
     while True:

--- a/export.py
+++ b/export.py
@@ -56,7 +56,9 @@ def main() -> None:
     cur.execute("SELECT * FROM tasks WHERE status='COMPLETE'")
     rows = cur.fetchall()
 
-    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    dirpath = os.path.dirname(args.output)
+    if dirpath:
+        os.makedirs(dirpath, exist_ok=True)
     out_path = f"{args.output}.{args.format}"
 
     if args.format == "csv":

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -58,13 +58,10 @@ def _load_prompts_from_config(config: Dict[str, Any]) -> list[str]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Orchestrate experiment setup")
-    parser.add_argument("--config", required=True, help="Path to YAML config file")
-    parser.add_argument(
-        "--setup-only",
-        action="store_true",
-        help="Only set up tasks and exit (default behaviour)",
+    parser = argparse.ArgumentParser(
+        description="Set up tasks in the database and exit"
     )
+    parser.add_argument("--config", required=True, help="Path to YAML config file")
     args = parser.parse_args()
 
     config = load_config(args.config)
@@ -83,12 +80,8 @@ def main() -> None:
             task_id = hashlib.sha256(key.encode("utf-8")).hexdigest()
             insert_task(conn, task_id, prompt, model["name"])
 
-    if args.setup_only:
-        print("Task setup complete: tasks stored in DB")
-        return
-
     print(
-        "Setup complete. Workers can now be started separately to process the tasks."
+        "Task setup complete: workers can now be started separately to process the tasks."
     )
 
 

--- a/task_db.py
+++ b/task_db.py
@@ -1,6 +1,6 @@
 import sqlite3
 import time
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS tasks (
@@ -46,24 +46,33 @@ def insert_task(conn: sqlite3.Connection, task_id: str, prompt: str, model_name:
     )
     conn.commit()
 
-def fetch_and_lock_tasks(conn: sqlite3.Connection, from_status: str, to_status: str, limit: int) -> List[sqlite3.Row]:
-    """Fetch tasks with a given status and immediately lock them by updating their status.
-
-    This prevents multiple workers from processing the same task concurrently.
-    """
+def fetch_and_lock_tasks(
+    conn: sqlite3.Connection, from_status: str, to_status: str, limit: int
+) -> List[sqlite3.Row]:
+    """Atomically fetch tasks with a given status and lock them by updating their status."""
     cur = conn.cursor()
+    cur.execute("BEGIN IMMEDIATE")
     cur.execute(
-        "SELECT * FROM tasks WHERE status=? LIMIT ?", (from_status, limit)
+        "SELECT task_id FROM tasks WHERE status=? LIMIT ?", (from_status, limit)
+    )
+    ids = [r[0] for r in cur.fetchall()]
+    if not ids:
+        conn.commit()
+        return []
+    placeholders = ",".join(["?"] * len(ids))
+    now = time.time()
+    cur.execute(
+        f"UPDATE tasks SET status=?, last_updated=? WHERE task_id IN ({placeholders}) AND status=?",
+        [to_status, now, *ids, from_status],
+    )
+    if cur.rowcount == 0:
+        conn.commit()
+        return []
+    cur.execute(
+        f"SELECT * FROM tasks WHERE task_id IN ({placeholders}) AND status=?",
+        [*ids, to_status],
     )
     rows = cur.fetchall()
-    if not rows:
-        return []
-    ids = [r["task_id"] for r in rows]
-    placeholders = ",".join(["?"] * len(ids))
-    cur.execute(
-        f"UPDATE tasks SET status=?, last_updated=? WHERE task_id IN ({placeholders})",
-        [to_status, time.time(), *ids],
-    )
     conn.commit()
     return rows
 


### PR DESCRIPTION
## Summary
- remove ineffective `--setup-only` flag from orchestrator and clarify CLI
- safeguard export output directory creation when no path is provided
- drop unused judge template loading and return only rubric
- make `fetch_and_lock_tasks` atomic with a transaction

## Testing
- `python -m py_compile *.py`
- `python orchestrator.py --config config.yaml`
- `python generation_worker.py --config config.yaml --batch-size 2`
- `python evaluation_worker.py --config config.yaml --batch-size 2`
- `python export.py --config config.yaml --format csv --output exported_tasks`


------
https://chatgpt.com/codex/tasks/task_e_68a1cfa7c8c88320b3f8e168df91f362