### PR TITLE
Expand evaluation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Reasoning Model Evaluation Pipeline
 
-이 프로젝트는 다양한 언어 모델의 **Reasoning(추론) 모드**를 정량적으로 비교하기 위한 실험 파이프라인입니다. 모든 구성은 하나의 `config.yaml` 파일로 제어되며, 워커들은 상태 기반으로 독립적으로 동작합니다.
+이 프로젝트는 **question/gold/category** 스키마를 따르는 데이터셋을 받아 언어 모델의 Base/Reasoning 응답을 생성하고 평가하는 실험 파이프라인입니다. 모든 동작은 하나의 `config.yaml`로 제어되며 워커들은 DB 상태를 통해 독립적으로 동작합니다.
 
 ## 구성 요소
-- `orchestrator.py`: 데이터셋과 모델 조합으로 태스크를 생성하여 DB에 저장합니다.
-- `generation_worker.py`: 모델 응답을 생성하고 DB 상태를 업데이트합니다.
-- `evaluation_worker.py`: 생성된 응답을 판정 프롬프트와 루브릭을 이용해 평가합니다.
-- `export.py`: 완료된 태스크를 CSV 또는 Parquet 파일로 추출합니다.
-- `prompts/`: YAML 형식의 판정 프롬프트(`judge_template.yaml`)와 루브릭(`general_rubric.yaml`)이 위치합니다.
+- `orchestrator.py`: 데이터셋을 로드하고 카테고리별 프롬프트를 생성하여 태스크(DB)에 등록합니다.
+- `generation_worker.py`: 각 태스크에 대해 `base_response`와 `reasoning_response`를 생성합니다.
+- `evaluation_worker.py`: 선택된 평가 모듈을 실행하여 점수와 판정 결과를 기록합니다.
+  - MCQA 정답 비교
+  - `math_verify` 기반 수학 검증
+  - LLM-as-Judge (개별/상대 비교) 평가
+- `export.py`: 완료된 태스크를 CSV 또는 Parquet 형식으로 추출합니다.
+- `prompts/`: 판정 프롬프트와 루브릭 YAML(`comparative_judge_template.yaml`, `general_rubric.yaml`)이 위치합니다.
 
 ## 빠른 시작
-1. `config.yaml` 내용을 환경에 맞게 수정합니다.
+1. `config.yaml`의 `dataset`과 `evaluation_worker.evaluations_to_run`을 실험에 맞게 수정합니다.
 2. 태스크 등록
    ```bash
    python orchestrator.py --config config.yaml --setup-only
@@ -27,5 +30,7 @@
    ```bash
    python export.py --config config.yaml --format csv
    ```
+
+수학 검증을 사용하려면 추가로 `pip install math-verify`를 실행하세요.
 
 자세한 사용 방법은 [`docs/usage_ko.md`](docs/usage_ko.md) 문서를 참고하십시오.

--- a/config.yaml
+++ b/config.yaml
@@ -7,14 +7,14 @@ database:
   path: "./tasks.db"
 
 dataset:
-  # You can provide inline prompts for quick tests (takes precedence over name/file)
-  prompts:
-    - "Compare reasoning vs base: What is 2+2?"
-    - "Write a short plan to cook pasta."
-  # name: "imdb"
-  # prompt_column: "text"
-  # split: "test[:5]"
-  sample_size: 2
+  # Inline records follow the standard question/gold/category schema
+  records:
+    - question: "What is 2+2?\nA. 3\nB. 4\nC. 5\nD. 6"
+      gold: "B"
+      category: "mcqa"
+    - question: "Solve 5 * 3."
+      gold: "15"
+      category: "math"
 
 models:
   - name: "tiny-gpt2"
@@ -40,13 +40,17 @@ generation_worker:
 
 evaluation_worker:
   replicas: 1
-  judge_model:
-    type: "openai"
-    name: "gpt-4-turbo"
-  judge_prompt_template_path: "./prompts/judge_template.yaml"
-  rubric_path: "./prompts/general_rubric.yaml"
-  choice_logic:
-    method: "higher_score"
+  evaluations_to_run:
+    - "mcqa"
+    - "math_verify"
+    - "llm_judge_comparative"
+    - "llm_judge_individual"
+  comparative_judge:
+    model: "gpt-4-turbo"
+    prompt_template_path: "./prompts/comparative_judge_template.yaml"
+  individual_judge:
+    model: "gpt-4-turbo"
+    rubric_path: "./prompts/general_rubric.yaml"
 
 logging:
   level: "INFO"

--- a/docs/usage_ko.md
+++ b/docs/usage_ko.md
@@ -4,16 +4,21 @@
 
 ## 1. 환경 준비
 - Python 3.10 이상을 권장합니다.
-- 필요한 패키지는 `pip install -r requirements.txt` 형식으로 설치할 수 있습니다. (현재 예시에서는 표준 라이브러리만 사용합니다.)
+- `math_verify` 기반 수학 평가가 필요하다면 `pip install math-verify`를 추가로 실행합니다.
 
 ## 2. 설정 파일 편집
 `config.yaml` 파일 하나로 실험을 제어합니다. 주요 항목은 다음과 같습니다.
 
 - `database`: SQLite 또는 PostgreSQL 등의 연결 정보를 지정합니다.
-- `dataset`: Hugging Face 데이터셋 이름과 사용할 열을 설정합니다.
+- `dataset`: Hugging Face 데이터셋 이름과 split을 지정하거나, 예시처럼 `records` 항목에 직접 데이터를 적을 수 있습니다. 모든 레코드는 `question`, `gold`, `category` 컬럼을 포함해야 합니다.
 - `models`: 평가할 모델 목록을 나열합니다.
 - `generation_worker`: 응답 생성과 관련된 설정과 추론 on/off 제어 파라미터를 포함합니다.
-- `evaluation_worker`: 판정에 사용할 프롬프트 템플릿과 루브릭 YAML 경로를 지정합니다.
+- `evaluation_worker`: 실행할 평가 모듈을 `evaluations_to_run` 리스트로 지정합니다.
+  - `mcqa`: 객관식 정답 비교
+  - `math_verify`: 수학 답안 검증
+  - `llm_judge_comparative`: Base vs Reasoning 상대 비교
+  - `llm_judge_individual`: 개별 응답 평가
+  - 각 Judge 설정은 `comparative_judge`와 `individual_judge` 블록에서 모델 이름, 프롬프트 템플릿, 루브릭 경로 등을 지정합니다.
 
 ## 3. 태스크 생성
 ```bash
@@ -31,7 +36,7 @@ python generation_worker.py --config config.yaml
 ```bash
 python evaluation_worker.py --config config.yaml
 ```
-평가 워커는 생성된 응답을 읽어 점수와 피드백을 부여하고 상태를 `COMPLETE`로 업데이트합니다.
+평가 워커는 `evaluations_to_run`에 명시된 모듈을 적용하여 정답 여부, 판정 결과 등을 기록하고 상태를 `COMPLETE`로 업데이트합니다.
 
 ## 6. 결과 내보내기
 ```bash

--- a/evaluation_worker.py
+++ b/evaluation_worker.py
@@ -9,8 +9,9 @@ call an external judge model such as GPT-4.
 from __future__ import annotations
 
 import argparse
+import re
 import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 
@@ -22,6 +23,12 @@ from task_db import (
     update_evaluation_success,
 )
 
+try:  # Optional dependency used for strict math checking
+    from math_verify import parse as mv_parse, verify as mv_verify
+    MATH_VERIFY_AVAILABLE = True
+except Exception:  # pragma: no cover - best effort import
+    MATH_VERIFY_AVAILABLE = False
+
 
 def load_config(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:
@@ -29,50 +36,163 @@ def load_config(path: str) -> Dict[str, Any]:
 
 
 def load_rubric(cfg: Dict[str, Any]) -> str:
-    """Load evaluation rubric from a YAML file."""
+    """Load evaluation rubric from a YAML file if provided."""
+    if not cfg or "rubric_path" not in cfg:
+        return ""
     with open(cfg["rubric_path"], "r", encoding="utf-8") as f:
         rubric_data = yaml.safe_load(f) or {}
     return rubric_data.get("rubric", "")
 
 
-def simple_judge(response: str, rubric: str) -> Dict[str, Any]:
-    """A naive evaluation heuristic.
+def load_prompt_template(cfg: Dict[str, Any]) -> str:
+    """Load comparative judge prompt template if provided."""
+    if not cfg or "prompt_template_path" not in cfg:
+        return ""
+    with open(cfg["prompt_template_path"], "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data.get("prompt", "")
 
-    Scores responses based on length as a stand-in for a real LLM judge.
-    The rubric text is appended to the feedback for demonstration purposes.
-    """
-    score = min(len(response) // 10, 10)  # 0-10 scale
+
+# ---------------------------------------------------------------------------
+# Evaluation modules
+# ---------------------------------------------------------------------------
+
+
+def _parse_math_answer(response: str) -> str:
+    """Extract the boxed answer or last number from a math response."""
+    match = re.search(r"\\boxed\{(.*?)\}", response)
+    if match:
+        return match.group(1).strip()
+    numbers = re.findall(r"[-+]?\d*\.?\d+", response)
+    return numbers[-1] if numbers else ""
+
+
+def _normalize_mqa_choice_advanced(response: str) -> str:
+    """Normalize various multiple-choice formats into a single letter."""
+    if not isinstance(response, str):
+        return ""
+    if "</think>" in response:
+        response = response.split("</think>", 1)[1]
+    match = re.search(r"정답은\s*([A-Ja-j1-5])\s*(?:입니다|이다)", response)
+    if match:
+        return match.group(1).upper().strip(".)")
+    choices = re.findall(r"[A-Ea-e1-5]", response)
+    if choices:
+        last = choices[-1]
+        if last.isdigit():
+            return chr(ord("A") + int(last) - 1)
+        return last.upper()
+    return response.strip().upper().strip(".)")
+
+def evaluate_llm_judge_individual(response: str, rubric: str) -> Dict[str, Any]:
+    """Placeholder individual LLM judge based on response length."""
+    score = min(len(response) // 10, 10)
     feedback = f"{rubric.strip()} | length={len(response)}" if rubric else f"length={len(response)}"
     return {"score": score, "feedback": feedback}
 
 
-def process_batch(conn, batch_size: int, rubric: str) -> int:
-    tasks = fetch_and_lock_tasks(
-        conn, "GENERATION_COMPLETE", "EVALUATING", batch_size
-    )
+def evaluate_mcqa(response: str, gold: str) -> bool:
+    """Advanced MCQA evaluator using robust choice parsing."""
+    if not gold:
+        return False
+    pred = _normalize_mqa_choice_advanced(response)
+    return pred == gold.strip().upper().strip(".)")
+
+
+def evaluate_math(response: str, gold: str) -> bool:
+    """Verify math answers using math_verify when available."""
+    if not gold:
+        return False
+    if MATH_VERIFY_AVAILABLE:
+        try:
+            parsed_gold = mv_parse(str(gold))
+            parsed_resp = mv_parse(response)
+            return bool(mv_verify(parsed_gold, parsed_resp))
+        except Exception:
+            return False
+    pred = _parse_math_answer(response)
+    return pred == str(gold).strip()
+
+
+def evaluate_llm_judge_comparative(
+    base_resp: str, reasoning_resp: str, template: str | None = None
+) -> Dict[str, str]:
+    """Placeholder comparative judge choosing the longer response.
+
+    The template argument is accepted for compatibility with future LLM-based
+    judging but is unused in this heuristic implementation.
+    """
+    if len(base_resp) > len(reasoning_resp):
+        choice = "base"
+    elif len(base_resp) < len(reasoning_resp):
+        choice = "reasoning"
+    else:
+        choice = "tie"
+    reasoning = f"base_len={len(base_resp)}, reasoning_len={len(reasoning_resp)}"
+    return {"choice": choice, "reasoning": reasoning}
+
+
+def process_batch(
+    conn, batch_size: int, evaluations: List[str], rubric: str, comp_prompt: str
+) -> int:
+    tasks = fetch_and_lock_tasks(conn, "GENERATION_COMPLETE", "EVALUATING", batch_size)
     if not tasks:
         return 0
 
     for row in tasks:
         task_id = row["task_id"]
         try:
-            base_eval = simple_judge(row["base_response"] or "", rubric)
-            reasoning_eval = simple_judge(row["reasoning_response"] or "", rubric)
-            # Determine choice
-            if base_eval["score"] > reasoning_eval["score"]:
+            base_resp = row["base_response"] or ""
+            reasoning_resp = row["reasoning_response"] or ""
+
+            # Individual judge scores
+            if "llm_judge_individual" in evaluations:
+                base_eval = evaluate_llm_judge_individual(base_resp, rubric)
+                reasoning_eval = evaluate_llm_judge_individual(reasoning_resp, rubric)
+                base_score = base_eval["score"]
+                reasoning_score = reasoning_eval["score"]
+                base_feedback = base_eval["feedback"]
+                reasoning_feedback = reasoning_eval["feedback"]
+            else:
+                base_score = reasoning_score = 0
+                base_feedback = reasoning_feedback = ""
+
+            # Objective correctness checks
+            base_is_correct = reasoning_is_correct = None
+            if "mcqa" in evaluations and row["gold"]:
+                base_is_correct = int(evaluate_mcqa(base_resp, row["gold"]))
+                reasoning_is_correct = int(evaluate_mcqa(reasoning_resp, row["gold"]))
+            elif "math_verify" in evaluations and row["gold"]:
+                base_is_correct = int(evaluate_math(base_resp, row["gold"]))
+                reasoning_is_correct = int(evaluate_math(reasoning_resp, row["gold"]))
+
+            # Comparative judge
+            judge_choice = judge_reasoning = None
+            if "llm_judge_comparative" in evaluations:
+                comp = evaluate_llm_judge_comparative(base_resp, reasoning_resp, comp_prompt)
+                judge_choice = comp["choice"]
+                judge_reasoning = comp["reasoning"]
+
+            # Determine choice based on scores
+            if base_score > reasoning_score:
                 choice = "base"
-            elif base_eval["score"] < reasoning_eval["score"]:
+            elif base_score < reasoning_score:
                 choice = "reasoning"
             else:
                 choice = "tie"
+
             update_evaluation_success(
                 conn,
                 task_id,
-                base_eval["score"],
-                reasoning_eval["score"],
-                base_eval["feedback"],
-                reasoning_eval["feedback"],
+                base_score,
+                reasoning_score,
+                base_feedback,
+                reasoning_feedback,
                 choice,
+                base_is_correct,
+                reasoning_is_correct,
+                judge_choice,
+                judge_reasoning,
             )
         except Exception as e:  # pragma: no cover
             update_evaluation_failure(conn, task_id, str(e))
@@ -88,11 +208,19 @@ def main() -> None:
     cfg = load_config(args.config)
     conn = get_connection(cfg["database"])
     init_db(conn)
-    rubric = load_rubric(cfg["evaluation_worker"])
+
+    ew_cfg = cfg.get("evaluation_worker", {})
+    evaluations = ew_cfg.get("evaluations_to_run", [])
+    rubric = load_rubric(ew_cfg.get("individual_judge", {})) if "llm_judge_individual" in evaluations else ""
+    comp_prompt = (
+        load_prompt_template(ew_cfg.get("comparative_judge", {}))
+        if "llm_judge_comparative" in evaluations
+        else ""
+    )
 
     processed = 0
     while True:
-        count = process_batch(conn, args.batch_size, rubric)
+        count = process_batch(conn, args.batch_size, evaluations, rubric, comp_prompt)
         if count == 0:
             break
         processed += count

--- a/generation_worker.py
+++ b/generation_worker.py
@@ -157,7 +157,7 @@ def process_batch(
     for row in tasks:
         task_id = row["task_id"]
         model_name = row["model_name"]
-        prompt = row["prompt"]
+        prompt = row["question"]
         try:
             model_id = model_map.get(model_name, model_name)
             base = generate_text(

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
-import time
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
 
@@ -33,28 +32,58 @@ def load_config(path: str) -> Dict[str, Any]:
         return yaml.safe_load(f)
 
 
-def _load_prompts_from_config(config: Dict[str, Any]) -> list[str]:
+def _load_dataset_from_config(config: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Load dataset records with question/gold/category fields."""
     dataset_cfg = config.get("dataset", {})
-    # 1) Inline prompts list
-    if isinstance(dataset_cfg.get("prompts"), list) and dataset_cfg["prompts"]:
-        prompts = [str(p) for p in dataset_cfg["prompts"]]
-    # 2) Local text file (one prompt per line)
-    elif isinstance(dataset_cfg.get("file"), str):
-        path = dataset_cfg["file"]
-        with open(path, "r", encoding="utf-8") as f:
-            prompts = [line.strip() for line in f if line.strip()]
-    # 3) Hugging Face datasets if available
+    records: List[Dict[str, str]] = []
+
+    # Inline records for quick tests
+    if isinstance(dataset_cfg.get("records"), list) and dataset_cfg["records"]:
+        for r in dataset_cfg["records"]:
+            if isinstance(r, dict):
+                records.append(
+                    {
+                        "question": str(r.get("question", "")),
+                        "gold": str(r.get("gold", "")),
+                        "category": str(r.get("category", "")),
+                    }
+                )
+    # Hugging Face dataset loader
     elif load_dataset is not None and dataset_cfg.get("name"):
         ds = load_dataset(dataset_cfg["name"], split=dataset_cfg.get("split", "train"))
-        prompts = ds[dataset_cfg.get("prompt_column", "prompt")]
+        for ex in ds:
+            records.append(
+                {
+                    "question": str(ex.get("question", "")),
+                    "gold": str(ex.get("gold", "")),
+                    "category": str(ex.get("category", "")),
+                }
+            )
     else:
-        # Fallback minimal prompts for offline usage
-        prompts = ["Say hello.", "Summarize: AI helps humans."]
+        # Fallback sample to keep pipeline functional offline
+        records = [
+            {
+                "question": "What is 1+1?\nA. 1\nB. 2",
+                "gold": "B",
+                "category": "mcqa",
+            }
+        ]
 
     sample_size = dataset_cfg.get("sample_size")
     if sample_size:
-        prompts = prompts[: int(sample_size)]
-    return prompts
+        records = records[: int(sample_size)]
+    return records
+
+
+def _prompt_for_category(rec: Dict[str, str]) -> str:
+    """Create the final prompt based on dataset category."""
+    category = (rec.get("category") or "").lower()
+    q = rec.get("question", "")
+    if "mcqa" in category or category.startswith("mcq"):
+        return f"{q}\nAnswer with the letter of the correct option."
+    if "math" in category:
+        return f"{q}\nProvide only the final answer."
+    return q
 
 
 def main() -> None:
@@ -70,15 +99,23 @@ def main() -> None:
     conn = get_connection(config["database"])
     init_db(conn)
 
-    # Load prompts (supports inline/file/HF datasets)
-    prompts = _load_prompts_from_config(config)
+    # Load dataset records
+    records = _load_dataset_from_config(config)
 
-    # Insert tasks for every (prompt, model) combination
-    for prompt in prompts:
+    # Insert tasks for every (question, model) combination
+    for rec in records:
+        prompt = _prompt_for_category(rec)
         for model in config.get("models", []):
             key = f"{prompt}\0{model['name']}"
             task_id = hashlib.sha256(key.encode("utf-8")).hexdigest()
-            insert_task(conn, task_id, prompt, model["name"])
+            insert_task(
+                conn,
+                task_id,
+                prompt,
+                rec.get("gold", ""),
+                rec.get("category", ""),
+                model["name"],
+            )
 
     print(
         "Task setup complete: workers can now be started separately to process the tasks."

--- a/prompts/comparative_judge_template.yaml
+++ b/prompts/comparative_judge_template.yaml
@@ -1,0 +1,2 @@
+prompt: |
+  You are a comparative judge. Compare two answers and decide which is better.

--- a/task_db.py
+++ b/task_db.py
@@ -2,11 +2,21 @@ import sqlite3
 import time
 from typing import Dict, List
 
+# The tasks table stores the complete lifecycle of a single evaluation
+# unit.  The original implementation only tracked prompts and simple
+# length based scores.  For the upgraded evaluation pipeline we expand the
+# schema so that structured questions, gold answers and multiple judge
+# outputs can be recorded.  Columns added:
+#   - question, gold, category: standardised dataset schema
+#   - base_is_correct, reasoning_is_correct: objective evaluation flags
+#   - judge_choice, judge_reasoning: comparative LLM-as-a-judge results
 SCHEMA = """
 CREATE TABLE IF NOT EXISTS tasks (
     task_id TEXT PRIMARY KEY,
     status TEXT,
-    prompt TEXT,
+    question TEXT,
+    gold TEXT,
+    category TEXT,
     model_name TEXT,
     base_response TEXT,
     reasoning_response TEXT,
@@ -14,7 +24,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     reasoning_score INTEGER,
     base_feedback TEXT,
     reasoning_feedback TEXT,
+    base_is_correct INTEGER,
+    reasoning_is_correct INTEGER,
     choice TEXT,
+    judge_choice TEXT,
+    judge_reasoning TEXT,
     last_updated REAL,
     error_log TEXT
 )
@@ -34,15 +48,24 @@ def init_db(conn: sqlite3.Connection) -> None:
     conn.execute(SCHEMA)
     conn.commit()
 
-def insert_task(conn: sqlite3.Connection, task_id: str, prompt: str, model_name: str) -> None:
+def insert_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    question: str,
+    gold: str,
+    category: str,
+    model_name: str,
+) -> None:
     """Insert a new task if it does not already exist."""
     now = time.time()
     conn.execute(
         """
-        INSERT OR IGNORE INTO tasks (task_id, status, prompt, model_name, last_updated)
-        VALUES (?, 'PENDING_GENERATION', ?, ?, ?)
+        INSERT OR IGNORE INTO tasks (
+            task_id, status, question, gold, category, model_name, last_updated
+        )
+        VALUES (?, 'PENDING_GENERATION', ?, ?, ?, ?, ?)
         """,
-        (task_id, prompt, model_name, now),
+        (task_id, question, gold, category, model_name, now),
     )
     conn.commit()
 
@@ -104,11 +127,22 @@ def update_evaluation_success(
     base_feedback: str,
     reasoning_feedback: str,
     choice: str,
+    base_is_correct: int | None = None,
+    reasoning_is_correct: int | None = None,
+    judge_choice: str | None = None,
+    judge_reasoning: str | None = None,
 ) -> None:
+    """Update evaluation results for a task.
+
+    All new evaluation fields are optional so that individual evaluation
+    modes can be toggled without schema churn.
+    """
     conn.execute(
         """
         UPDATE tasks SET status='COMPLETE', base_score=?, reasoning_score=?,
-            base_feedback=?, reasoning_feedback=?, choice=?, last_updated=?
+            base_feedback=?, reasoning_feedback=?, choice=?,
+            base_is_correct=?, reasoning_is_correct=?,
+            judge_choice=?, judge_reasoning=?, last_updated=?
         WHERE task_id=?
         """,
         (
@@ -117,6 +151,10 @@ def update_evaluation_success(
             base_feedback,
             reasoning_feedback,
             choice,
+            base_is_correct,
+            reasoning_is_correct,
+            judge_choice,
+            judge_reasoning,
             time.time(),
             task_id,
         ),


### PR DESCRIPTION
## Summary
- refine MCQA answer parsing and math verification with optional math_verify
- load comparative judge prompt template and pass to evaluation modules
- document evaluation modules and dataset schema in README and usage guide

## Testing
- `python orchestrator.py --config config.yaml`
- `python generation_worker.py --config config.yaml --batch-size 2`
- `python evaluation_worker.py --config config.yaml --batch-size 2`


------
https://chatgpt.com/codex/tasks/task_e_68a31e133ed08320981dec9583d0e173